### PR TITLE
Force the port to be an Integer

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clams "0.1.0"
+(defproject clams "0.1.1"
   :description "Clojure with Clams. A framework for web apps."
   :url "https://github.com/standardtreasury/clams"
   :license {:name "The MIT License"

--- a/src/clams/app.clj
+++ b/src/clams/app.clj
@@ -1,6 +1,7 @@
 (ns clams.app
   (:require [clams.conf :as conf]
             [clams.route :refer [compile-routes]]
+            [clams.util :refer [str->int]]
             [org.httpkit.server :as httpkit]
             ring.middleware.http-response
             ring.middleware.json
@@ -47,7 +48,7 @@
     (when (nil? @server)
       (conf/load!)
       (let [middleware (:middleware opts)
-            port       (conf/get :port)]
+            port       (str->int (conf/get :port))]
         (reset! server (httpkit/run-server (app app-ns middleware) {:port port}))))))
 
 (defn stop-server

--- a/src/clams/util.clj
+++ b/src/clams/util.clj
@@ -20,3 +20,11 @@
     (list 'defmacro m
       '[& args]
       `(concat (list (quote ~(fully-qualified-symbol ns m))) ~(quote args))))))
+
+(defn str->int
+  "Convert a string to an integral number."
+  [s]
+  (when s
+    (if (number? s)
+        s
+        (Long/parseLong s))))

--- a/test/clams/test/util_test.clj
+++ b/test/clams/test/util_test.clj
@@ -32,3 +32,15 @@
   (let [publics (ns-publics this-ns)]
     (is (contains? publics 'm1))
     (is (= (:macro (meta (get publics 'm1))) true))))
+
+(deftest test-str->int
+  (testing "str->int"
+    (is (= (str->int "0") 0))
+    (is (= (str->int "1") 1))
+    (is (= (str->int "-1") -1))
+    (is (= (str->int "123") 123))
+    (is (= (str->int 123) 123))
+    (is (= (str->int -1) -1))
+    (is (= (str->int "2147483647") 2147483647))
+    (is (= (str->int "2147483648") 2147483648))
+    (is (nil? (str->int nil)))))


### PR DESCRIPTION
When the port is set as an environment vairable, Clams sees it as a
string.  This forces the port to be an Integer no matter how it is
set.