### PR TITLE
Only build the middleware handler once

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clams "0.1.1"
+(defproject clams "0.1.2"
   :description "Clojure with Clams. A framework for web apps."
   :url "https://github.com/standardtreasury/clams"
   :license {:name "The MIT License"

--- a/src/clams/app.clj
+++ b/src/clams/app.clj
@@ -37,9 +37,11 @@
     (require routes-ns)
     (compile-routes app-ns (var-get (ns-resolve routes-ns 'routes)))))
 
-(defn app
-  [app-ns app-middleware]
-  (wrap-middleware (routes app-ns) (concat default-middleware app-middleware)))
+(defn app [app-ns app-middleware]
+  (let [handler (wrap-middleware (routes app-ns)
+                                 (concat default-middleware app-middleware))]
+    (fn [request]
+      (handler request))))
 
 (defn start-server
   ([app-ns]


### PR DESCRIPTION
Previously, we were building the handler for every request and this
reset the state of functions that kept state (such as wrap-reload).