### PR TITLE
Add migrations to clams.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clams "0.1.2"
+(defproject clams "0.2.0"
   :description "Clojure with Clams. A framework for web apps."
   :url "https://github.com/standardtreasury/clams"
   :license {:name "The MIT License"
@@ -6,13 +6,17 @@
   :dependencies
     [
      [clout "2.0.0"]
+     [com.novemberain/monger "3.0.0-rc2"]
      [compojure "1.2.0"]
      [http-kit "2.1.19"]
      [metosin/ring-http-response "0.5.2"]
      [org.clojure/clojure "1.6.0"]
      [org.clojure/tools.macro "0.1.5"]
+     [org.postgresql/postgresql "9.3-1102-jdbc41"]
      [prismatic/schema "0.3.1"]
+     [ragtime "0.4.1"]
      [ring "1.3.1"]
      [ring-mock "0.1.5"]
      [ring/ring-json "0.3.1"]
-    ])
+     ]
+    :aot [clams.migrate])

--- a/src/clams/migrate.clj
+++ b/src/clams/migrate.clj
@@ -1,0 +1,121 @@
+(ns clams.migrate
+  "Database migrations management alternative main/entry-point.
+  This is runnable using `lein run -m clams.migrate` or compiled using
+  `java -cp uberjar.jar clams.migrate`. See usage below for more details.
+
+  For SQL migrations:
+  - Add a database-url config entry
+  - Place migrations in resources/migrations with an `up` and `down`
+    migration.  The migrations will be run in the lexical order by file
+    name.  Each file should be named `PREFIX.{up,down}.sql`.  For
+    example `001-foo.up.sql`
+  - The migrations should contain pure SQL.
+  - Also see  https://github.com/weavejester/ragtime/wiki/Getting-Started
+
+  For Mongo migrations:
+  - Add a mongo-url config entry
+  - Place migrations in resources/migrations with an `up` and `down`
+    migration.  The migrations will be run in the lexical order by file
+    name.  Each file should be named `PREFIX.{up,down}.mongoclj`.  For
+    example `001-foo.up.mongoclj`
+  - The migrations should contain Clojure code where each migration
+    is responsible for connecting to the mongo instance itself.
+  - Also see  https://github.com/weavejester/ragtime/wiki/Getting-Started
+  "
+  (:require
+   [clams.conf :as conf]
+   [clams.util :refer [str->int]]
+   [monger.core :as mg]
+   monger.ragtime                       ; Force load of Mongo ragtime/Migratable code
+   [ragtime.jdbc :as jdbc]
+   [ragtime.repl :as repl])
+  (:import
+   [java.io File])
+  (:gen-class))
+
+;;; Mongo migration interface
+;;;
+;;; A replication of the Ragtime jdbc code to support our mongo
+;;; migrations.  Mongo migrations are just Clojure files that are
+;;; executed by Ragtime.
+;;;
+
+(let [pattern (re-pattern (str "([^" File/separator "]*)" File/separator "?$"))]
+  (defn- basename [file]
+    (second (re-find pattern (str file)))))
+
+(defn- remove-extension [file]
+  (second (re-matches #"(.*)\.[^.]*" (str file))))
+
+;; We are using the .mongoclj extension
+(defn- mongoclj-file-parts [file]
+  (rest (re-matches #"(.*?)\.(up|down)(?:\.(\d+))?\.mongoclj" (str file))))
+
+(defn- gen-load-fn
+  "Generate a function the loads the mongo migrations.  The migration
+   is responsible for connecting to the mongo instance."
+  [urls]
+  (fn [_]
+    (doseq [u urls]
+      (load-string (slurp u)))))
+
+(defmethod jdbc/load-files ".mongoclj" [files]
+  (for [[id files] (group-by (comp first mongoclj-file-parts) files)]
+    (let [{:strs [up down]} (group-by (comp second mongoclj-file-parts) files)]
+      {:scheme :mongo
+       :id (basename id)
+       :up (gen-load-fn up)
+       :down (gen-load-fn down)})))
+
+;;;
+;;; Run migrations
+;;;
+
+(defn- mongo-config
+  "The config only exists if the database exists and there are
+   relevant migrations."
+  []
+  (when-let [url (conf/get :mongo-url)]
+    (let [ms (filter #(= :mongo (:scheme %)) (jdbc/load-resources "migrations"))]
+      (when (seq ms)
+        {:database (:db (mg/connect-via-uri url))
+         :migrations ms}))))
+
+(defn- sql-config []
+  "The config only exists if the database exists and there are
+   relevant migrations."
+  (when-let [url (conf/get :database-url)]
+    (let [ms (remove :scheme (jdbc/load-resources "migrations"))] ; No scheme means jdbc
+      (when (seq ms)
+        {:database (jdbc/sql-database {:connection-uri url})
+         :migrations ms}))))
+
+(defn- run-migrations
+  ([f] (run-migrations f nil))
+  ([f n]
+   (doseq [config [(sql-config) (mongo-config)]]
+     (when config
+       (if n
+           (f config n)
+           (f config))))))
+
+(def usage
+  "Manage database migrations.
+
+Usage: lein run -m clams.migrate <COMMAND> <ARGS>
+
+Commands:
+  migrate           Migrate to the latest version
+  rollback [n]      Rollback n versions (defaults to 1)")
+
+(defn -main
+  "Run the migrations or rollbacks"
+  [& args]
+  (println "Running migrations")
+  (case (first args)
+    "migrate" (run-migrations repl/migrate)
+    "rollback" (if-let [n (second args)]
+                 (run-migrations repl/rollback (str->int n))
+                 (run-migrations repl/rollback))
+    (do (println usage)
+        (System/exit 1))))

--- a/test/clams/test/migrate_test.clj
+++ b/test/clams/test/migrate_test.clj
@@ -1,0 +1,50 @@
+(ns clams.test.migrate-test
+  (:require
+   [clojure.test :refer :all]
+   [clams.migrate :as migrate]
+   [ragtime.jdbc :as jdbc]
+   ))
+
+(deftest read-empty-configs-test
+  (is (nil? (#'migrate/sql-config)))
+  (is (nil? (#'migrate/mongo-config)))
+  )
+
+(def fake-migrations
+  [{:scheme :mongo
+    :id "001-foo"
+    :up (constantly "foo")
+    :down (constantly "foo")}
+   {:scheme :mongo
+    :id "002-bar"
+    :up (constantly "bar")
+    :down (constantly "bar")}
+   {:scheme :jdbc
+    :id "003-baz"
+    :up (constantly "baz")
+    :down (constantly "baz")}])
+
+(def fake-conf {:mongo-url "mongo url"})
+
+(deftest mongo-config-test
+  (with-redefs [ragtime.jdbc/load-resources (constantly fake-migrations)
+                monger.core/connect-via-uri (constantly {:db "mongo handle"})
+                clams.conf/get (fn [k] (get fake-conf k))]
+    (is (= {:database "mongo handle" :migrations (take 2 fake-migrations)}
+           (#'migrate/mongo-config)))
+
+    (let [state (atom nil)]
+      (is (= nil
+             (#'migrate/run-migrations (fn [c] (swap! state conj c)))))
+      (is (= [{:database "mongo handle" :migrations (take 2 fake-migrations)}]
+             @state)))
+    ))
+
+(deftest load-files-test
+  (let [migrations (jdbc/load-files ["/abc/migrate/001-foo.up.mongoclj"
+                                     "/abc/migrate/001-foo.down.mongoclj"
+                                     "/abc/migrate/002-bar.up.mongoclj"])]
+    (is (= ["001-foo" "002-bar"] (map :id migrations)))
+    (is (= [:mongo] (distinct (map :scheme migrations))))
+    (is (= 2 (count (filter identity (map :up migrations)))))
+    (is (= 2 (count (filter identity (map :down migrations)))))))


### PR DESCRIPTION
- This is a lot of functionality, so bumped the minor number
- Supports SQL and Mongo, so added those jars to the deps
- Docs in https://github.com/standardtreasury/clams/wiki/Migrations
- Yes, this works in an uber jar