### PR TITLE
Force a heroku PG url into the right format

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clams "0.2.0"
+(defproject clams "0.2.1"
   :description "Clojure with Clams. A framework for web apps."
   :url "https://github.com/standardtreasury/clams"
   :license {:name "The MIT License"


### PR DESCRIPTION
If it's a Heroku postgres URL, we tweak it to be a format that ragtime
accepts.  Otherwise we leave it alone.