### PR TITLE
Change the migration strategy to apply all new migrations

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject clams "0.2.6"
+(defproject clams "0.3.0"
   :description "Clojure with Clams. A framework for web apps."
   :url "https://github.com/standardtreasury/clams"
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
   :dependencies
-    [
+  [
      [clout "2.1.2"]
      [com.novemberain/monger "3.0.0-rc2"]
      [compojure "1.4.0"]

--- a/src/clams/migrate.clj
+++ b/src/clams/migrate.clj
@@ -28,7 +28,8 @@
    [monger.core :as mg]
    monger.ragtime                       ; Force load of Mongo ragtime/Migratable code
    [ragtime.jdbc :as jdbc]
-   [ragtime.repl :as repl])
+   [ragtime.repl :as repl]
+   ragtime.strategy)
   (:import
    [java.io File])
   (:gen-class))
@@ -103,7 +104,8 @@
     (let [ms (remove :scheme (load-resources))] ; No scheme means jdbc
       (when (seq ms)
         {:database (jdbc/sql-database {:connection-uri (format-jdbc-url url)})
-         :migrations (sort-by :id ms)}))))
+         :migrations (sort-by :id ms)
+         :strategy ragtime.strategy/apply-new}))))
 
 (defn- run-migrations
   ([f] (run-migrations f nil))


### PR DESCRIPTION
This is a substantial change from the old migration raise-error
strategy which raises an error if applied out of lexical order.